### PR TITLE
add the posibility to send an object to sort and add the test for that

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ function convertSort(sort) {
 
   const result = {};
 
-  Object.keys(sort).forEach(key => result[key] = parseInt(sort[key], 10));
+  Object.keys(sort).forEach(key => result[key] = typeof sort[key] === 'object' ? sort[key] : parseInt(sort[key], 10));
 
   return result;
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -17,6 +17,12 @@ describe('Feathers Query Filters', function() {
       expect(query).to.deep.equal({});
     });
 
+    it('returns $sort when present in query as an object', function() {
+      const { filters, query } = filter({ $sort: { name: {something: 10} } });
+      expect(filters.$sort.name.something).to.equal(10);
+      expect(query).to.deep.equal({});
+    });
+
     it('converts strings in $sort', function() {
       const { filters, query } = filter({ $sort: { test: '-1' } });
       expect(filters.$sort.test).to.equal(-1);


### PR DESCRIPTION
Sometime we need to add an object to a sort, in the case of using full text search with weight in mongoose

example:

```javascript
Model
    .find(
        { $text : { $search : "text to look for" } }, 
        { score : { $meta: "textScore" } }
    )
    .sort({ score : { $meta : 'textScore' } })
    .exec(function(err, results) {
        // callback
    });
```

with this change allow me to do this in a hook

```javascript
if (hook.params.query.q) {
    hook.params.query.$text = {
        $search: hook.params.query.q
    }
    hook.params.query.$select = {
        score: {
            $meta: "textScore"
        }
    };
    hook.params.query.$sort = {
        score: {
            $meta: 'textScore'
        }
    };
    delete hook.params.query.q;
}
```