### PR TITLE
Replace lodash.omit with feathers-commons utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lib": "lib"
   },
   "dependencies": {
-    "lodash.omit": "^4.3.0"
+    "feathers-commons": "^0.7.8"
   },
   "devDependencies": {
     "babel-cli": "^6.4.5",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-const omit = require('lodash.omit');
+import { _ } from 'feathers-commons/lib/utils';
+
 const PROPERTIES = ['$sort', '$limit', '$skip', '$select', '$populate'];
 
 function parse (number) {
@@ -36,5 +37,5 @@ export default function (query, paginate) {
     $populate: query.$populate
   };
 
-  return { filters, query: omit(query, ...PROPERTIES) };
+  return { filters, query: _.omit(query, ...PROPERTIES) };
 }


### PR DESCRIPTION
Since feathers-commons is usually already being used in feathers projects, might as well re-use it. Also more lightweight for use in the frontend